### PR TITLE
Use `renderToString()` for `renderReactWithStyledComponents()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export const renderReactWithStyledComponents = (name, component) =>
       return (props) => {
         const sheet = new ServerStyleSheet();
         const element = React.createElement(component, props);
-        const html = ReactDOMServer.renderToStaticMarkup(element);
+        const html = ReactDOMServer.renderToString(element);
         const css = sheet.getStyleTags();
         const markup = serialize(name, html, props);
         return `${css}\n${markup}`;


### PR DESCRIPTION
This PR replaces `renderToStaticMarkup()` in `renderReactWithStyledComponents()` with `renderToString()` because the former one is not for Server-Side Rendering.

ref. https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup